### PR TITLE
Improve company signup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,22 @@
     - `Backup & restore DB`
     - `Interact with Django Core`
     - `Manage Environment`
-    - `Manage Dependencies`  
+    - `Manage Dependencies`
 - [Deployment](https://app-generator.dev/docs/deployment.html)
-  - Docker/Docker Compose Scripts 
+  - Docker/Docker Compose Scripts
   - CI/CD for [Render](https://app-generator.dev/docs/deployment/render/index.html)
-- [Vite](https://app-generator.dev/docs/technologies/vite/index.html) for assets management 
+- [Vite](https://app-generator.dev/docs/technologies/vite/index.html) for assets management
+
+## Company Sign-Up
+
+Only the first administrator should create an account using the company sign-up page:
+
+```
+/company/signup/
+```
+
+This flow creates both the user and the company. Additional members are invited from the
+administration area once signed in.
 
 ## [Documentation](https://app-generator.dev/docs/products/django/material-dashboard-pro/index.html)
 

--- a/apps/companies/urls.py
+++ b/apps/companies/urls.py
@@ -4,5 +4,7 @@ from . import views
 urlpatterns = [
     path('signup/', views.signup_company, name='signup_company'),
     path('signup/success/', views.signup_success, name='signup_success'),
+    path('info/', views.company_info, name='company_info'),
+    path('users/', views.company_users, name='company_users'),
 ]
 

--- a/templates/accounts/signin/basic.html
+++ b/templates/accounts/signin/basic.html
@@ -65,7 +65,7 @@
                   </div>
                   <p class="mt-4 text-sm text-center">
                     Don't have an account?
-                    <a href="{% url "basic_register" %}" class="text-primary text-gradient font-weight-bold">Sign up</a>
+                    <a href="{% url 'signup_company' %}" class="text-primary text-gradient font-weight-bold">Create Company</a>
                   </p>
                 </form>
               </div>

--- a/templates/accounts/signin/cover.html
+++ b/templates/accounts/signin/cover.html
@@ -52,7 +52,7 @@
             <div class="card-footer text-center pt-0 px-lg-2 px-1">
               <p class="mb-4 text-sm mx-auto">
                 Don't have an account?
-                <a href="{% url "cover_register" %}" class="text-success text-gradient font-weight-bold">Sign up</a>
+                <a href="{% url 'signup_company' %}" class="text-success text-gradient font-weight-bold">Create Company</a>
               </p>
             </div>
           </div>

--- a/templates/accounts/signin/illustration.html
+++ b/templates/accounts/signin/illustration.html
@@ -50,7 +50,7 @@
                 <div class="card-footer text-center pt-0 px-lg-2 px-1">
                   <p class="mb-4 text-sm mx-auto">
                     Don't have an account?
-                    <a href="{% url "illustration_register" %}" class="text-primary text-gradient font-weight-bold">Sign up</a>
+                    <a href="{% url 'signup_company' %}" class="text-primary text-gradient font-weight-bold">Create Company</a>
                   </p>
                 </div>
               </div>

--- a/templates/companies/company_info.html
+++ b/templates/companies/company_info.html
@@ -1,0 +1,19 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+<div class="container py-4">
+  <div class="row">
+    <div class="col-md-8 mx-auto">
+      <div class="card">
+        <div class="card-header"><h5 class="mb-0">Company Information</h5></div>
+        <div class="card-body">
+          <ul class="list-group">
+            <li class="list-group-item"><strong>Name:</strong> {{ company.name }}</li>
+            <li class="list-group-item"><strong>Plan:</strong> {{ company.plan }}</li>
+            <li class="list-group-item"><strong>Created By:</strong> {{ company.created_by.username }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/companies/company_users.html
+++ b/templates/companies/company_users.html
@@ -1,0 +1,21 @@
+{% extends "layouts/base.html" %}
+{% block content %}
+<div class="container py-4">
+  <div class="row">
+    <div class="col-md-8 mx-auto">
+      <div class="card">
+        <div class="card-header"><h5 class="mb-0">Company Users</h5></div>
+        <div class="card-body">
+          <ul class="list-group">
+            {% for profile in users %}
+            <li class="list-group-item">{{ profile.user.username }} - {{ profile.role }}</li>
+            {% empty %}
+            <li class="list-group-item">No users found.</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/includes/navigation-full.html
+++ b/templates/includes/navigation-full.html
@@ -242,23 +242,11 @@
                         </a>
                       </div>
                     </li>
-                    <li class="nav-item dropdown dropdown-hover dropdown-subitem list-group-item border-0 p-0">
-                      <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" id="dropdownSignUp">
+                    <li class="nav-item list-group-item border-0 p-0">
+                      <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" href="{% url 'signup_company' %}">
                         <i class="material-symbols-rounded opacity-6 me-2 text-md">assignment</i>
-                        <span>Sign Up</span>
-                        <img src="{% static "assets/img/down-arrow.svg" %}" alt="down-arrow" class="arrow ms-auto">
+                        <span>Create Company</span>
                       </a>
-                      <div class="dropdown-menu mt-0 py-3 px-2" aria-labelledby="dropdownSignUp">
-                        <a class="dropdown-item ps-3 border-radius-md mb-1" href="{% url "basic_register" %}">
-                          <span>Basic</span>
-                        </a>
-                        <a class="dropdown-item ps-3 border-radius-md mb-1" href="{% url "cover_register" %}">
-                          <span>Cover</span>
-                        </a>
-                        <a class="dropdown-item ps-3 border-radius-md" href="{% url "illustration_register" %}">
-                          <span>Illustration</span>
-                        </a>
-                      </div>
                     </li>
                     <li class="nav-item dropdown dropdown-hover dropdown-subitem list-group-item border-0 p-0">
                       <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" id="dropdownPasswordReset">
@@ -349,17 +337,9 @@
                   </a>
                   <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">
                     <i class="material-symbols-rounded opacity-6 me-2 text-md">assignment</i>
-                    Sign Up
+                    Create Company
                   </h6>
-                  <a href="{% url "basic_register" %}" class="dropdown-item border-radius-md ps-4">
-                    Basic
-                  </a>
-                  <a href="{% url "cover_register" %}" class="dropdown-item border-radius-md ps-4">
-                    Cover
-                  </a>
-                  <a href="{% url "illustration_register" %}" class="dropdown-item border-radius-md ps-4">
-                    Illustration
-                  </a>
+                  <a href="{% url 'signup_company' %}" class="dropdown-item border-radius-md ps-4">Create Company</a>
                   <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">
                     <i class="material-symbols-rounded opacity-6 me-2 text-md">restart_alt</i>
                     Reset Password

--- a/templates/includes/navigation-shadow.html
+++ b/templates/includes/navigation-shadow.html
@@ -246,23 +246,11 @@
                               </a>
                             </div>
                           </li>
-                          <li class="nav-item dropdown dropdown-hover dropdown-subitem list-group-item border-0 p-0">
-                            <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" id="dropdownSignUp">
+                          <li class="nav-item list-group-item border-0 p-0">
+                            <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" href="{% url 'signup_company' %}">
                               <i class="material-symbols-rounded opacity-6 me-2 text-md">assignment</i>
-                              <span>Sign Up</span>
-                              <img src="{% static "assets/img/down-arrow.svg" %}" alt="down-arrow" class="arrow ms-auto">
+                              <span>Create Company</span>
                             </a>
-                            <div class="dropdown-menu mt-0 py-3 px-2" aria-labelledby="dropdownSignUp">
-                              <a class="dropdown-item ps-3 border-radius-md mb-1" href="{% url "basic_register" %}">
-                                <span>Basic</span>
-                              </a>
-                              <a class="dropdown-item ps-3 border-radius-md mb-1" href="{% url "cover_register" %}">
-                                <span>Cover</span>
-                              </a>
-                              <a class="dropdown-item ps-3 border-radius-md" href="{% url "illustration_register" %}">
-                                <span>Illustration</span>
-                              </a>
-                            </div>
                           </li>
                           <li class="nav-item dropdown dropdown-hover dropdown-subitem list-group-item border-0 p-0">
                             <a class="dropdown-item border-radius-md ps-3 d-flex align-items-center mb-1 text-dark" id="dropdownPasswordReset">
@@ -353,17 +341,9 @@
                         </a>
                         <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">
                           <i class="material-symbols-rounded opacity-6 me-2 text-md">assignment</i>
-                          Sign Up
+                          Create Company
                         </h6>
-                        <a href="{% url "basic_register" %}" class="dropdown-item border-radius-md ps-4">
-                          Basic
-                        </a>
-                        <a href="{% url "cover_register" %}" class="dropdown-item border-radius-md ps-4">
-                          Cover
-                        </a>
-                        <a href="{% url "illustration_register" %}" class="dropdown-item border-radius-md ps-4">
-                          Illustration
-                        </a>
+                        <a href="{% url 'signup_company' %}" class="dropdown-item border-radius-md ps-4">Create Company</a>
                         <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">
                           <i class="material-symbols-rounded opacity-6 me-2 text-md">restart_alt</i>
                           Reset Password

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -142,6 +142,36 @@
         <li class="nav-item mt-3">
           <h6 class="ps-3  ms-2 text-uppercase text-xs font-weight-bolder text-dark">PAGES</h6>
         </li>
+        {% if request.user.is_authenticated and request.user.profile.role == 'admin' %}
+        <li class="nav-item">
+          <a data-bs-toggle="collapse" href="#companyMenu" class="nav-link text-dark {% if parent == 'company' %}active{% endif %}" aria-controls="companyMenu" role="button" aria-expanded="false">
+            <i class="material-symbols-rounded opacity-5">business</i>
+            <span class="nav-link-text ms-1 ps-1">Company</span>
+          </a>
+          <div class="collapse {% if parent == 'company' %}show{% endif %}" id="companyMenu">
+            <ul class="nav ">
+              <li class="nav-item {% if segment == 'info' %}active{% endif %}">
+                <a class="nav-link text-dark {% if segment == 'info' %}active{% endif %}" href="{% url 'company_info' %}">
+                  <span class="sidenav-mini-icon"> I </span>
+                  <span class="sidenav-normal  ms-1  ps-1"> Info </span>
+                </a>
+              </li>
+              <li class="nav-item {% if segment == 'users' %}active{% endif %}">
+                <a class="nav-link text-dark {% if segment == 'users' %}active{% endif %}" href="{% url 'company_users' %}">
+                  <span class="sidenav-mini-icon"> U </span>
+                  <span class="sidenav-normal  ms-1  ps-1"> Users </span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link text-dark" target="_blank" href="//{{ request.company.slug_subdomain }}.{{ request.get_host }}/">
+                  <span class="sidenav-mini-icon"> V </span>
+                  <span class="sidenav-normal  ms-1  ps-1"> Visit Site </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        {% endif %}
         <li class="nav-item">
           <a data-bs-toggle="collapse" href="#pagesExamples" class="nav-link text-dark {% if parent == 'pages' %}active{% endif %}" aria-controls="pagesExamples" role="button" aria-expanded="false">
             <i class="material-symbols-rounded opacity-5 {% if page.brand == 'RTL' %}ms-2{% else %} me-2{% endif %}">contract</i>
@@ -478,32 +508,10 @@
                 </div>
               </li>
               <li class="nav-item ">
-                <a class="nav-link text-dark " data-bs-toggle="collapse" aria-expanded="false" href="#signupExample">
+                <a class="nav-link text-dark " href="{% url 'signup_company' %}">
                   <span class="sidenav-mini-icon"> S </span>
-                  <span class="sidenav-normal  ms-1  ps-1"> Sign Up <b class="caret"></b></span>
+                  <span class="sidenav-normal  ms-1  ps-1"> Create Company </span>
                 </a>
-                <div class="collapse " id="signupExample">
-                  <ul class="nav nav-sm flex-column">
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "basic_register" %}">
-                        <span class="sidenav-mini-icon"> B </span>
-                        <span class="sidenav-normal  ms-1  ps-1"> Basic </span>
-                      </a>
-                    </li>
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "cover_register" %}">
-                        <span class="sidenav-mini-icon"> C </span>
-                        <span class="sidenav-normal  ms-1  ps-1"> Cover </span>
-                      </a>
-                    </li>
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "illustration_register" %}">
-                        <span class="sidenav-mini-icon"> I </span>
-                        <span class="sidenav-normal  ms-1  ps-1"> Illustration </span>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
               </li>
               {% if request.user.is_authenticated %}
               <li class="nav-item ">

--- a/templates/pages/pages/landing-page.html
+++ b/templates/pages/pages/landing-page.html
@@ -19,7 +19,7 @@
         <li class="nav-item"><a class="nav-link" href="{% url 'index' %}">{% trans "Dashboard" %}</a></li>
         {% else %}
         <li class="nav-item"><a class="nav-link" href="{% url 'basic_login' %}">{% trans "Login" %}</a></li>
-        <li class="nav-item"><a class="nav-link" href="{% url 'basic_register' %}">{% trans "Register" %}</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'signup_company' %}">{% trans "Create Company" %}</a></li>
         {% endif %}
       </ul>
     </div>
@@ -32,7 +32,7 @@
   <div class="container text-center">
     <h1 class="display-4 mb-3 fade-scroll">{% trans "Manage your business effortlessly" %}</h1>
     <p class="lead fade-scroll">{% trans "Secuvast CRM helps you track customers, inventory and finances in one place." %}</p>
-    <a class="btn btn-primary btn-lg mt-4" href="{% url 'basic_register' %}">{% trans "Get started" %}</a>
+    <a class="btn btn-primary btn-lg mt-4" href="{% url 'signup_company' %}">{% trans "Get started" %}</a>
   </div>
 </section>
 

--- a/templates/pages/pages/rtl-page.html
+++ b/templates/pages/pages/rtl-page.html
@@ -416,32 +416,10 @@
                 </div>
               </li>
               <li class="nav-item ">
-                <a class="nav-link text-dark " data-bs-toggle="collapse" aria-expanded="false" href="#signupExample">
+                <a class="nav-link text-dark " href="{% url 'signup_company' %}">
                   <span class="sidenav-mini-icon"> S </span>
-                  <span class="sidenav-normal  me-3  ps-1"> Sign Up <b class="caret"></b></span>
+                  <span class="sidenav-normal  me-3  ps-1"> Create Company </span>
                 </a>
-                <div class="collapse " id="signupExample">
-                  <ul class="nav nav-sm flex-column">
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "basic_register" %}">
-                        <span class="sidenav-mini-icon"> B </span>
-                        <span class="sidenav-normal  me-3  ps-1"> Basic </span>
-                      </a>
-                    </li>
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "cover_register" %}">
-                        <span class="sidenav-mini-icon"> C </span>
-                        <span class="sidenav-normal  me-3  ps-1"> Cover </span>
-                      </a>
-                    </li>
-                    <li class="nav-item">
-                      <a class="nav-link text-dark " href="{% url "illustration_register" %}">
-                        <span class="sidenav-mini-icon"> I </span>
-                        <span class="sidenav-normal  me-3  ps-1"> Illustration </span>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
               </li>
               <li class="nav-item ">
                 <a class="nav-link text-dark " data-bs-toggle="collapse" aria-expanded="false" href="#resetExample">


### PR DESCRIPTION
## Summary
- add visit-site link under Company menu
- update nav links to point to company signup
- replace regular sign-up pages with company signup link
- document the signup process in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686c8d01843c8322968ff3e15efc67cf