### PR TITLE
Fix redirect loops for unknown subdomains

### DIFF
--- a/apps/companies/middleware.py
+++ b/apps/companies/middleware.py
@@ -19,8 +19,9 @@ class SubdomainCompanyMiddleware:
         if cache.get(cache_key):
             request.company = None
             set_current_company(None)
-            if subdomain not in ("www", ""):
-                return HttpResponseRedirect(reverse("company_not_found"))
+            not_found_url = reverse("company_not_found")
+            if subdomain not in ("www", "") and request.path != not_found_url:
+                return HttpResponseRedirect(not_found_url)
             return self.get_response(request)
         try:
             if request.path == reverse("company_healthz"):
@@ -35,6 +36,8 @@ class SubdomainCompanyMiddleware:
             request.company = None
             if subdomain not in ("www", ""):
                 set_current_company(None)
-                return HttpResponseRedirect(reverse("company_not_found"))
+                not_found_url = reverse("company_not_found")
+                if request.path != not_found_url:
+                    return HttpResponseRedirect(not_found_url)
         set_current_company(request.company)
         return self.get_response(request)

--- a/tests/test_multitenant.py
+++ b/tests/test_multitenant.py
@@ -107,3 +107,9 @@ def test_sidebar_hidden_without_company(client):
     resp = client.get(reverse("landing"), HTTP_HOST="www.example.com")
     assert resp.status_code == 200
     assert b"/company/info/" not in resp.content
+
+
+@pytest.mark.django_db
+def test_not_found_no_redirect_loop(client):
+    resp = client.get(reverse("company_not_found"), HTTP_HOST="miss.example.com")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- prevent redirect loops for unknown subdomains in `SubdomainCompanyMiddleware`
- test that `/company/not-found/` doesn't redirect again

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db31fe984832287663cc8ca597f30