### PR TITLE
Update Celery broker configuration

### DIFF
--- a/.env
+++ b/.env
@@ -8,5 +8,4 @@ SECRET_KEY=<STRONG_KEY_HERE>
 # DB_USERNAME=appseed_db_usr
 # DB_PASS=pass
 # DB_PORT=3306
-
-CELERY_BROKER_URL=redis://localhost:6379
+CELERY_BROKER_URL=redis://redis:6379


### PR DESCRIPTION
## Summary
- use the `redis` hostname for Celery broker in `.env`

## Testing
- `pytest -q`
- `docker compose up -d --build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686db32040f083228e4cf5823e30d502