### PR TITLE
Fix tenant redirects and templates

### DIFF
--- a/apps/companies/context_processors.py
+++ b/apps/companies/context_processors.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.conf import settings
 from .models import Company
 from .plans import PLAN_LIMITS
 
@@ -19,3 +20,7 @@ def company_brand(request):
         },
         "plan_usage": {"used": used, "limit": limit},
     }
+
+
+def root_domain(request):
+    return {"root_domain": settings.SAAS_ROOT_DOMAIN}

--- a/apps/companies/redirect_middleware.py
+++ b/apps/companies/redirect_middleware.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponseRedirect
+from django.conf import settings
 
 class EnsureSubdomainMiddleware:
     """Redirect authenticated users to their company subdomain."""
@@ -20,18 +21,11 @@ class EnsureSubdomainMiddleware:
         ):
 
             host = request.get_host()
-            host_parts = host.split(":", 1)
-            base_host = host_parts[0]
-            port = ":" + host_parts[1] if len(host_parts) == 2 else ""
+            port = ""
+            if ":" in host:
+                port = ":" + host.split(":", 1)[1]
 
-            parts = base_host.split(".")
-            if parts[0] == "www" and len(parts) > 1:
-                base_domain = ".".join(parts[1:])
-            elif len(parts) <= 2:
-                base_domain = base_host
-            else:
-                base_domain = ".".join(parts[1:])
-
+            base_domain = settings.SAAS_ROOT_DOMAIN
             new_host = f"{company.slug_subdomain}.{base_domain}{port}"
             return HttpResponseRedirect(f"//{new_host}{request.get_full_path()}")
         return self.get_response(request)

--- a/config/settings.py
+++ b/config/settings.py
@@ -52,7 +52,13 @@ INTERNAL_IPS = [
 ]
 
 # Add here your deployment HOSTS
-CSRF_TRUSTED_ORIGINS = ['http://localhost:8000', 'http://localhost:5085', 'http://127.0.0.1:8000', 'http://127.0.0.1:5085', 'https://django-material-dash2-pro.onrender.com'] 
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:8000',
+    'http://localhost:5085',
+    'http://127.0.0.1:8000',
+    'http://127.0.0.1:5085',
+    'https://django-material-dash2-pro.onrender.com',
+]
 
 # Application definition
 
@@ -135,6 +141,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'apps.companies.context_processors.company_brand',
+                'apps.companies.context_processors.root_domain',
             ],
         },
     },
@@ -381,4 +388,8 @@ STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY', '')
 STRIPE_WEBHOOK_SECRET = os.getenv('STRIPE_WEBHOOK_SECRET', '')
 STRIPE_PRO_PRICE_ID = os.getenv('STRIPE_PRO_PRICE_ID', '')
 SAAS_ROOT_DOMAIN = os.getenv('SAAS_ROOT_DOMAIN', 'localhost')
+# Ensure session and CSRF cookies work across subdomains used for tenants
+SESSION_COOKIE_DOMAIN = f".{SAAS_ROOT_DOMAIN}"
+CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
+CSRF_TRUSTED_ORIGINS += [f'http://*.{SAAS_ROOT_DOMAIN}:5085']
 ########################################

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -6,7 +6,7 @@
   {% if request.user.is_superuser %}
   {% active_companies as companies %}
   <form style="display:inline-block;margin-left:1em;" method="get" action="">
-    <select onchange="if(this.value){location.href='//' + this.value + '.{{ request.get_host }}{% url 'admin:index' %}';}">
+    <select onchange="if(this.value){location.href='//' + this.value + '.{{ root_domain }}{% if request.get_port != '80' and request.get_port != '443' %}:{{ request.get_port }}{% endif %}{% url 'admin:index' %}';}">
       <option value="">Switch company</option>
       {% for c in companies %}
       <option value="{{ c.slug_subdomain }}">{{ c.name }}</option>

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -173,7 +173,7 @@
               </li>
               <li class="nav-item">
 
-                <a class="nav-link text-dark" target="_blank" href="//{{ request.company.slug_subdomain }}.{{ request.get_host }}/">
+                <a class="nav-link text-dark" target="_blank" href="//{{ request.company.slug_subdomain }}.{{ root_domain }}{% if request.get_port != '80' and request.get_port != '443' %}:{{ request.get_port }}{% endif %}/">
                   <span class="sidenav-mini-icon"> V </span>
                   <span class="sidenav-normal  ms-1  ps-1"> Visit Site </span>
                 </a>


### PR DESCRIPTION
## Summary
- build tenant host using SAAS_ROOT_DOMAIN so redirects go to the right domain
- show root domain in templates
- update admin and sidebar links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dbaf4341c832285459cbc42b67355