### PR TITLE
Fix registration error & restore subdomain redirect

### DIFF
--- a/apps/pages/urls.py
+++ b/apps/pages/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path('pages/team/profile-overview/', views.profile_overview, name="profile_overview"),
     path('pages/team/projects/', views.all_projects, name="projects"),
     path('pages/profile/projects/', views.projects, name="profile_projects"),
-    path('pages/team/messages/', views.messages, name="messages"),
+    path('pages/team/messages/', views.team_messages, name="team_messages"),
     path('pages/team/reports/', views.reports, name="reports"),
     path('pages/team/new-user/', views.new_user, name="new_user"),
     # Pages -> Accounts

--- a/apps/pages/views.py
+++ b/apps/pages/views.py
@@ -86,7 +86,7 @@ def projects(request):
   return render(request, 'pages/profile/projects.html', context)
 
 
-def messages(request):
+def team_messages(request):
   context = {
     'parent': 'team',
     'segment': 'messages'

--- a/config/settings.py
+++ b/config/settings.py
@@ -100,6 +100,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     "whitenoise.middleware.WhiteNoiseMiddleware",
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'apps.companies.root_redirect_middleware.RootDomainRedirectMiddleware',
 
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'apps.companies.user_middleware.CurrentUserMiddleware',

--- a/templates/includes/navigation-full.html
+++ b/templates/includes/navigation-full.html
@@ -67,7 +67,7 @@
                       <a href="{% url "profile_overview" %}" class="dropdown-item border-radius-md">
                         <span class="ps-2">Overview</span>
                       </a>
-                      <a href="{% url "messages" %}" class="dropdown-item border-radius-md">
+                      <a href="{% url "team_messages" %}" class="dropdown-item border-radius-md">
                         <span class="ps-2">Messages</span>
                       </a>
                       <a href="{% url "projects" %}" class="dropdown-item border-radius-md">
@@ -169,7 +169,7 @@
                 <a href="{% url "projects" %}" class="dropdown-item border-radius-md">
                   Projects
                 </a>
-                <a href="{% url "messages" %}" class="dropdown-item border-radius-md">
+                <a href="{% url "team_messages" %}" class="dropdown-item border-radius-md">
                   Messages
                 </a>
                 <div class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">

--- a/templates/includes/navigation-shadow.html
+++ b/templates/includes/navigation-shadow.html
@@ -71,7 +71,7 @@
                             <a href="{% url "profile_overview" %}" class="dropdown-item border-radius-md">
                               <span class="ps-2">Overview</span>
                             </a>
-                            <a href="{% url "messages" %}" class="dropdown-item border-radius-md">
+                            <a href="{% url "team_messages" %}" class="dropdown-item border-radius-md">
                               <span class="ps-2">Messages</span>
                             </a>
                             <a href="{% url "projects" %}" class="dropdown-item border-radius-md">
@@ -173,7 +173,7 @@
                       <a href="{% url "projects" %}" class="dropdown-item border-radius-md">
                         Projects
                       </a>
-                      <a href="{% url "messages" %}" class="dropdown-item border-radius-md">
+                      <a href="{% url "team_messages" %}" class="dropdown-item border-radius-md">
                         Messages
                       </a>
                       <div class="dropdown-header text-dark font-weight-bolder d-flex align-items-center mt-3 px-0">

--- a/templates/includes/sidebar.html
+++ b/templates/includes/sidebar.html
@@ -421,7 +421,7 @@
                 </a>
               </li>
               <li class="nav-item {% if segment == 'messages' %}active{% endif %}">
-                <a class="nav-link text-dark {% if segment == 'messages' %}active{% endif %}" href="{% url "messages" %}">
+                <a class="nav-link text-dark {% if segment == 'messages' %}active{% endif %}" href="{% url "team_messages" %}">
                   <span class="sidenav-mini-icon"> M </span>
                   <span class="sidenav-normal  ms-1  ps-1"> Messages </span>
                 </a>

--- a/templates/pages/pages/rtl-page.html
+++ b/templates/pages/pages/rtl-page.html
@@ -326,7 +326,7 @@
                 </a>
               </li>
               <li class="nav-item ">
-                <a class="nav-link text-dark " href="{% url "messages" %}">
+                <a class="nav-link text-dark " href="{% url "team_messages" %}">
                   <span class="sidenav-mini-icon"> M </span>
                   <span class="sidenav-normal  me-3  ps-1"> Messages </span>
                 </a>


### PR DESCRIPTION
## Summary
- rename `messages` view to `team_messages` to avoid clashing with Django messages API
- update URLs and templates to reference `team_messages`
- enable `RootDomainRedirectMiddleware` so old subdomains redirect correctly
- adjust sidebar and navigation links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0e01d7cc8322a5ee9a42a2917c22